### PR TITLE
workflow-fixes: Enchance unit test verbosity and update cypresss configuration after feedback from @annechh

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,8 +29,7 @@ export default [
     files: ["**/*.cy.js", "cypress.config.js"],
     languageOptions: {
       globals: {
-        cy: "readonly",
-        Cypress: "readonly",
+        ...globals.cypress,
       },
     },
     plugins: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "sass src/scss:dist/css",
     "test": "npm run test-unit",
-    "test-unit": "jest",
+    "test-unit": "jest --verbose",
     "test-e2e": "cypress open",
     "start": "sass --watch src/scss:dist/css & live-server",
     "lint": "eslint .",


### PR DESCRIPTION
**Pull request description:**

- Enabled verbose mode for unit testing by updating the `test-unit` script to use `jest --verbose` to get more details when running tests.
- Updated the ESLint configuration to properly handle Cypress globals by setting `cy` and `Cypress `to `readonly`:
 - Added `cy `and `Cypress `to the `globals `object to ensure consistent linting across the codebase.
 - Removed redundant Cypress global declarations from spesific files configurations. 

**- Incorporated feedback from @annechh and made adjustments accordingly.**


